### PR TITLE
Spinner and done icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 NVIM plugin to notify about LSP processes
 
-### Motivation 
+### Motivation
 
-The motivation was to address the uncertainty that can sometimes accompany using LSP. 
+The motivation was to address the uncertainty that can sometimes accompany using LSP.
 I wanted to create a solution that would provide better visibility into the LSP's processes.
 
 ### Examples
@@ -30,7 +30,7 @@ use {
 }
 ```
 
-You can also pass `notify` function, for example from [nvim-notify](https://github.com/rcarriga/nvim-notify):
+You can pass `notify` function, for example from [nvim-notify](https://github.com/rcarriga/nvim-notify):
 ```lua
 use {
   'mrded/nvim-lsp-notify',
@@ -38,6 +38,35 @@ use {
   config = function()
     require('lsp-notify').setup({
       notify = require('notify'),
+    })
+  end
+}
+```
+
+Or `icons` to customize icons:
+```lua
+use {
+  'mrded/nvim-lsp-notify',
+  requires = { 'rcarriga/nvim-notify' },
+  config = function()
+    require('lsp-notify').setup({
+      icons = {
+        spinner = { '|', '/', '-', '\\' },      -- `= false` to disable only this icon
+        done = '!'                              -- `= false` to disable only this icon
+      }
+    })
+  end
+}
+```
+
+Or `icons = false` to disable them completely:
+```lua
+use {
+  'mrded/nvim-lsp-notify',
+  requires = { 'rcarriga/nvim-notify' },
+  config = function()
+    require('lsp-notify').setup({
+      icons = false
     })
   end
 }

--- a/doc/zond.txt
+++ b/doc/zond.txt
@@ -6,7 +6,7 @@ lsp-notify is a plugin designed to keep you informed of the progress of your LSP
 
 setup({opts})                                               *lsp-notify.setup()*
     Configure nvim-lsp-notify
-    
+
     Parameters: ~
         {opts}                (table)         options to pass to the function
 

--- a/doc/zond.txt
+++ b/doc/zond.txt
@@ -13,3 +13,18 @@ setup({opts})                                               *lsp-notify.setup()*
     Options: ~
         {notify}              (function)      function to show the notification
                                               (default: 'vim.notify')
+        {icons}               (table|false)   icons to display or 'false' to
+                                              disable
+                                              (default: {
+                                                 spinner = {
+                                                   "⣾",
+                                                   "⣽",
+                                                   "⣻",
+                                                   "⢿",
+                                                   "⡿",
+                                                   "⣟",
+                                                   "⣯",
+                                                   "⣷"
+                                                 },
+                                                 done = "󰗡"
+                                              })

--- a/lua/lsp-notify/init.lua
+++ b/lua/lsp-notify/init.lua
@@ -51,12 +51,12 @@ vim.lsp.handlers["$/progress"] = function(_, result, ctx)
 
     notif_data.notification = options.notify(message, "info", {
       title = title,
-      icon = options.icons.spinner and options.icons.spinner[1] or nil,
+      icon = (options.icons and options.icons.spinner) and options.icons.spinner[1] or nil,
       timeout = false,
       hide_from_history = false,
     })
 
-    if options.icons.spinner then
+    if options.icons and options.icons.spinner then
       notif_data.spinner = 1
       update_spinner(client_id, result.token)
     end
@@ -73,7 +73,7 @@ vim.lsp.handlers["$/progress"] = function(_, result, ctx)
     local message = val.message or "Complete"
 
     notif_data.notification = options.notify(message, "info", {
-      icon = options.icons.done or nil,
+      icon = options.icons and options.icons.done or nil,
       replace = notif_data.notification,
       timeout = 3000,
     })
@@ -96,10 +96,9 @@ end
 ---@class LspNotifyConfig
 local default_options = {
   notify = vim.notify,
+  ---@type {spinner: string[] | false, done: string | false} | false
   icons = {
-    ---@type string[] | false
     spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
-    ---@type string | false
     done = "󰗡"
   }
 }

--- a/lua/lsp-notify/init.lua
+++ b/lua/lsp-notify/init.lua
@@ -1,4 +1,5 @@
-local notify = vim.notify
+---@type LspNotifyConfig
+local options = nil
 
 local client_notifs = {}
 
@@ -13,6 +14,25 @@ local function get_notif_data(client_id, token)
 
   return client_notifs[client_id][token]
 end
+
+local function update_spinner(client_id, token)
+  local notif_data = get_notif_data(client_id, token)
+
+  if notif_data.spinner then
+    notif_data.spinner = (notif_data.spinner % #options.icons.spinner) + 1
+
+    notif_data.notification = options.notify(nil, nil, {
+      hide_from_history = true,
+      icon = options.icons.spinner[notif_data.spinner],
+      replace = notif_data.notification,
+    })
+
+    vim.defer_fn(function()
+      update_spinner(client_id, token)
+    end, 100)
+  end
+end
+
 
 vim.lsp.handlers["$/progress"] = function(_, result, ctx)
   local val = result.value
@@ -29,16 +49,22 @@ vim.lsp.handlers["$/progress"] = function(_, result, ctx)
     local message = val.message or "Loading..."
     local title = val.title or vim.lsp.get_client_by_id(client_id).name or "Notification"
 
-    notif_data.notification = notify(message, "info", {
+    notif_data.notification = options.notify(message, "info", {
       title = title,
+      icon = options.icons.spinner and options.icons.spinner[1] or nil,
       timeout = false,
       hide_from_history = false,
     })
 
+    if options.icons.spinner then
+      notif_data.spinner = 1
+      update_spinner(client_id, result.token)
+    end
+
   elseif val.kind == "report" and notif_data then
     local message = (val.percentage and val.percentage .. "%\t" or "") .. (val.message or "")
 
-    notif_data.notification = notify(message, "info", {
+    notif_data.notification = options.notify(message, "info", {
       replace = notif_data.notification,
       hide_from_history = false,
     })
@@ -46,10 +72,13 @@ vim.lsp.handlers["$/progress"] = function(_, result, ctx)
   elseif val.kind == "end" and notif_data then
     local message = val.message or "Complete"
 
-    notif_data.notification = notify(message, "info", {
+    notif_data.notification = options.notify(message, "info", {
+      icon = options.icons.done or nil,
       replace = notif_data.notification,
       timeout = 3000,
     })
+
+    notif_data.spinner = nil
   end
 end
 
@@ -61,15 +90,23 @@ vim.lsp.handlers["window/showMessage"] = function(err, method, params, client_id
     "info",
     "info", -- map both hint and info to info?
   }
-  notify(method.message, severity[params.type], { title = "LSP" })
+  options.notify(method.message, severity[params.type], { title = "LSP" })
 end
 
-return {
-  setup = function(opts)
-    opts = opts or {}
+---@class LspNotifyConfig
+local default_options = {
+  notify = vim.notify,
+  icons = {
+    ---@type string[] | false
+    spinner = { "⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷" },
+    ---@type string | false
+    done = "󰗡"
+  }
+}
 
-    if opts.notify then
-      notify = opts.notify
-    end
+return {
+  ---@param opts LspNotifyConfig?
+  setup = function(opts)
+    options = vim.tbl_deep_extend("force", default_options, opts or {})
   end
 }


### PR DESCRIPTION
Added spinner and done icons:

![image](https://user-images.githubusercontent.com/44075969/225536907-f9d9c024-351a-4f5f-b9ae-b8e2a202153a.png)
![image](https://user-images.githubusercontent.com/44075969/225536964-49d4b034-7912-4725-89ef-8cac4fccdd04.png)

These icons can be customized or disabled separately:
```lua
require('lsp-notify').setup {
    icons = {
        spinner = { '/', '-', '|', '\\' },    -- or `= false` to disable
        done = '!'                            -- or `= false` to disable
    }
}
```
Or disabled together:
```lua
require('lsp-notify').setup {
    icons = false
}
```

The code is taken from [usage recipes](https://github.com/rcarriga/nvim-notify/wiki/Usage-Recipes/#progress-updates) with some slight modifications to handle that the icons are optional.