### PR TITLE
fix startup error hidding suport notification

### DIFF
--- a/lua/lsp-notify/init.lua
+++ b/lua/lsp-notify/init.lua
@@ -27,8 +27,8 @@ local supports_replace = false
 ---@return boolean suppors
 local function check_supports_replace()
   local n = options.notify(
-    "",
-    nil,
+    "lsp notify: test replace support",
+    vim.log.levels.DEBUG,
     {
       hide_from_history = true,
       on_open = function(window)
@@ -49,7 +49,7 @@ local function check_supports_replace()
       animate = false
     }
   )
-  local supports = pcall(options.notify, nil, nil, { replace = n })
+  local supports = pcall(options.notify, "lsp notify: test replace support", vim.log.levels.DEBUG, { replace = n })
   return supports
 end
 


### PR DESCRIPTION
This should mediate issue #11 by avoiding both the error and the empty notification, since debug level notifications don't show up by default.

Please verify this does not brake your replace validation.