### PR TITLE
fix: do not replace non existing notifications + protect error-prone function calls

### DIFF
--- a/lua/lsp-notify/init.lua
+++ b/lua/lsp-notify/init.lua
@@ -27,7 +27,7 @@ local options = {
 local supports_replace = false
 
 --- Check if current notification system supports replacing notifications.
----@return boolean suppors
+---@return boolean supports
 local function check_supports_replace()
   local n = options.notify(
     "lsp notify: test replace support",

--- a/lua/lsp-notify/init.lua
+++ b/lua/lsp-notify/init.lua
@@ -196,12 +196,17 @@ function BaseLspNotification:notification_progress()
       {
         replace = self.notification,
         hide_from_history = false,
+        on_close = function()
+          self.notification = nil
+          self.window = nil
+        end
       }
     )
     if self.window then
       -- Update height because `nvim-notify` notifications don't do it automatically
       -- Can cover other notifications
-      vim.api.nvim_win_set_height(
+      pcall(
+        vim.api.nvim_win_set_height,
         self.window,
         3 + message_lines
       )
@@ -226,7 +231,11 @@ function BaseLspNotification:notification_end()
     {
       replace = self.notification,
       icon = options.icons and options.icons.done or nil,
-      timeout = 1000
+      timeout = 1000,
+      on_close = function()
+        self.notification = nil
+        self.window = nil
+      end
     }
   )
   if self.window then
@@ -303,13 +312,21 @@ function BaseLspNotification:spinner_start()
           hide_from_history = true,
           icon = options.icons.spinner[self.spinner],
           replace = self.notification,
+          on_close = function()
+            self.notification = nil
+            self.window = nil
+          end
         }
       )
     end
 
     -- Trigger new spinner frame
     vim.defer_fn(function()
-      self:spinner_start()
+      -- We need to pcall here because passing `nil` as a message sometimes trigger an error
+      -- If we pass an empty string as nvim-notify wants, it'll flicker
+      pcall(function()
+        self:spinner_start()
+      end)
     end, 100)
   end
 end


### PR DESCRIPTION
When I dismiss the "LSP loading" message, I have an infinite stream of "No matching notification found to replace" spamming me.
The problem was that the spinner was trying to replace the notification that I just dismissed, the solution was to set the `self.notification` to `nil` when closing the notification(s).

The next problem that arose was due to `self.window` having the same problem and triggering an error, the solution was to set it to `nil` as well, one particular call (line `208`) sometimes was called before `nvim-notify` had the time to set `self.window` to `nil`, so I wrapped it in a `pcall` to suppress the error.

Lastly, it's a hack I've seen in other plugins but `options.notify` expects a `string` as first parameter (`msg`), passing an empty string causes the message to flicker when the spinner animates so it needs to stay `nil`.

My solution was to`pcall` `spinner_start` (line `325`).

I tried to change as little code as possible and this was the only way I've found to solve that bug.

This would fix #13 